### PR TITLE
removes version from composer.json to allow for versioning via tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "clever/clever-php",
     "description": "Clever PHP library",
-    "version": "0.1",
     "homepage": "http://getclever.com/",
     "require": {
         "php": ">=5.2"


### PR DESCRIPTION
Installing "*" via composer is fraught with danger.

https://igor.io/2013/01/07/composer-versioning.html

https://getcomposer.org/doc/01-basic-usage.md#package-versions

I also recommend tagging a v0.1.1 or some such.
