### PR TITLE
Calling ->district() on a CleverSchool object results in a CleverObject object, not a CleverDistrict object.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "fixedd/clever-php",
-    "description": "fixedd's version of the Clever PHP library",
+    "name": "digedu/clever-php",
+    "description": "digedu's version of the Clever PHP library",
     "require": {
         "php"    : ">=5.3",
         "psr/log": "~1.0"

--- a/lib/Clever/Util.php
+++ b/lib/Clever/Util.php
@@ -52,6 +52,14 @@ abstract class CleverUtil
           preg_match( '/^\/(\S*)\/(\S+)s\/(\S*)$/', $resp['uri'], $match ) &&
           isset($types[$match[2]])) {
         $class = $types[$match[2]];
+      } else if (array_key_exists('links', $resp) && count($resp['links']) > 0) {
+	    $class = 'CleverObject';
+	    foreach ($resp['links'] as $link) {
+		  if ($link['rel'] == 'self' && preg_match( '/^\/(\S*)\/(\S+)s\/(\S*)$/', $link['uri'], $match ) &&
+              isset($types[$match[2]])) {
+            $class = $types[$match[2]];
+          }
+        }
       } else {
         $class = 'CleverObject';
       }


### PR DESCRIPTION
This code:

```
$school = CleverSchool::retrieve('ABC123');
$district = $school->district();
var_dump($district);
```

results in:

```
object(CleverObject)#6 (3) {
  ["_auth":protected]=>
  array(1) {
    ["apiKey"]=>
    string(32) "ABC123"
  }
  ["_values":protected]=>
  array(3) {
    ["id"]=>
    string(24) "123123123123123123"
    ["name"]=>
    string(21) "#DEMO Sandbox" 
    ["mdr_number"]=>
    string(0) ""
  }
  ["logger":protected]=>
  object(Psr\Log\NullLogger)#7 (0) {   
  }
}
```

So, a CleverObject instead of the expected CleverDistrict.  

I'm not sure if this pull request is the best solution to the problem, but it seems to have solved the problem for me.
