### PR TITLE
Invalid class in response to an undocumented response.

### DIFF
--- a/lib/Clever/ApiRequestor.php
+++ b/lib/Clever/ApiRequestor.php
@@ -68,11 +68,6 @@ class CleverApiRequestor
                                            $rcode, $rbody, $resp);
     case 401:
       throw new CleverAuthenticationError(isset($error['message']) ? $error['message'] : null, $rcode, $rbody, $resp);
-    case 402:
-      throw new CleverInvalidRequest(isset($error['message']) ? $error['message'] : null,
-                                 isset($error['param']) ? $error['param'] : null,
-                                 isset($error['code']) ? $error['code'] : null,
-                                 $rcode, $rbody, $resp);
     default:
       throw new CleverError(isset($error['message']) ? $error['message'] : null, $rcode, $rbody, $resp);
     }


### PR DESCRIPTION
`ApiRequestor->handleApiError()` references the class `CleverInvalidRequest`, but that class is not defined anywhere. Suspect it's intending to reference `CleverInvalidRequestError`, but the signatures don't match. It's also attempting to catch a response (402) that [the documentation](https://clever.com/developers/docs#guide-getting-started-api-responses-section) does not list as a possible response from the API. Further, NONE of the other Clever-supplied libraries are attempting to catch this response type.
