### PR TITLE
endpoints that don't end in "s" ...

### DIFF
--- a/lib/Clever/Util.php
+++ b/lib/Clever/Util.php
@@ -2,62 +2,117 @@
 
 abstract class CleverUtil
 {
-  public static function isList($array)
-  {
-    if (!is_array($array))
-      return false;
-    // TODO: this isn't actually correct in general
-    foreach (array_keys($array) as $k) {
-      if (!is_numeric($k))
-        return false;
-    }
-    return true;
-  }
 
-  public static function convertCleverObjectToArray($values)
-  {
-    $results = array();
-    foreach ($values as $k => $v) {
-      // FIXME: this is an encapsulation violation
-      if (CleverObject::$_permanentAttributes->includes($k)) {
-        continue;
-      }
-      if ($v instanceof CleverObject) {
-        $results[$k] = $v->__toArray(true);
-      } else if (is_array($v)) {
-        $results[$k] = self::convertCleverObjectToArray($v);
-      } else {
-        $results[$k] = $v;
-      }
-    }
-    return $results;
-  }
+	/**
+	 * the api uses both singular and plural nouns
+	 */
+	static $types = array(
+		'district'  => 'CleverDistrict',
+		'districts' => 'CleverDistrict',
+		'school'    => 'CleverSchool',
+		'schools'   => 'CleverSchool',
+		'teacher'   => 'CleverTeacher',
+		'teachers'  => 'CleverTeacher',
+		'students'  => 'CleverStudent',
+		'sections'  => 'CleverSection',
+		'events'    => 'CleverEvent',
+	);
 
-  public static function convertToCleverObject($resp, $auth)
-  {
-    $types = array('district' => 'CleverDistrict',
-                   'school' => 'CleverSchool',
-                   'teacher' => 'CleverTeacher',
-                   'student' => 'CleverStudent',
-                   'section' => 'CleverSection',
-                   'event' => 'CleverEvent');
-    if (is_array($resp) && array_key_exists('data', $resp) && self::isList($resp['data'])) {
-      $mapped = array();
-      foreach ($resp['data'] as $i) {
-        array_push($mapped, self::convertToCleverObject($i, $auth));
-      }
-      return $mapped;
-    } else if (is_array($resp) && array_key_exists('data', $resp)) {
-      if (isset($resp['uri']) && is_string($resp['uri']) &&
-          preg_match( '/^\/(\S*)\/(\S+)s\/(\S*)$/', $resp['uri'], $match ) &&
-          isset($types[$match[2]])) {
-        $class = $types[$match[2]];
-      } else {
-        $class = 'CleverObject';
-      }
-      return CleverObject::scopedConstructFrom($class, $resp['data'], $auth);
-    } else {
-      return $resp;
-    }
-  }
+	public static function isList($array)
+	{
+		if (!is_array($array))
+			return false;
+		// TODO: this isn't actually correct in general
+		foreach (array_keys($array) as $k) {
+			if (!is_numeric($k))
+				return false;
+		}
+		return true;
+	}
+
+	public static function convertCleverObjectToArray($values)
+	{
+		$results = array();
+		foreach ($values as $k => $v) {
+			// FIXME: this is an encapsulation violation
+			if (CleverObject::$_permanentAttributes->includes($k)) {
+				continue;
+			}
+			if ($v instanceof CleverObject) {
+				$results[$k] = $v->__toArray(true);
+			} else if (is_array($v)) {
+				$results[$k] = self::convertCleverObjectToArray($v);
+			} else {
+				$results[$k] = $v;
+			}
+		}
+		return $results;
+	}
+
+	public static function convertToCleverObject($resp, $auth)
+	{
+
+		if(is_array($resp) && !array_key_exists('data', $resp)){
+			return $resp;
+		}
+
+		if(isset($resp['data']) && static::isList($resp['data'])){
+			$mapped = array();
+			foreach ($resp['data'] as $i) {
+				$mapped[] = self::convertToCleverObject($i, $auth);
+			}
+			return $mapped;
+		}
+
+		$class = "";
+		if (isset($resp['uri']) && is_string($resp['uri'])){
+			$class = static::parseUriForClass($resp['uri']);
+		}
+
+		//because the API can't return a URI? -- singular object(s)
+		if (isset($resp['links']) && is_array($resp['links'])){
+			$class = static::parseUriForClass($resp['links'][0]["uri"]);
+		}
+
+		if(isset(static::$types[$class])){
+			$class = static::$types[$class];
+			return CleverObject::scopedConstructFrom($class, $resp['data'], $auth);
+		}
+
+		return $resp;
+
+	}
+
+	protected static function parseUriForClass($uri)
+	{
+
+		$uri = explode("/", $uri);
+
+		// $uri[0] is a throw away
+
+		// $version = "";
+		// if(array_key_exists(1, $uri)){
+		// 	$version = $uri[1];
+		// }
+
+		$endpoint = "CleverObject";
+		if(array_key_exists(2, $uri)){
+			$endpoint = $uri[2];
+		}
+
+		// $id = "";
+		// if(array_key_exists(3, $uri)){
+		// 	$id = $uri[3];
+		// }
+
+		// $etc = "";
+		// if(array_key_exists(4, $uri)){
+		// 	$etc = $uri[4];
+		// }
+
+		return $endpoint;
+		// return array($version, $endpoint, $id, $etc);
+
+	}
+
 }

--- a/test/Clever/DistrictTest.php
+++ b/test/Clever/DistrictTest.php
@@ -38,10 +38,11 @@ class CleverDistrictTest extends PHPUnit_Framework_TestCase
                               'events'   => 'CleverEvent');
     foreach ($secondLevelTests as $k => $v) {
       $objs = $district->$k();
+      $objs = is_array($objs) ? $objs : array($objs) ;
       foreach ($objs as $obj) {
         $this->assertEquals(get_class($obj), $v);
         if ($k != "events") {
-          $this->assertEquals($obj->instanceUrl(), '/' . $k . '/' . $obj->id);
+          $this->assertEquals($obj->instanceUrl(), '/' . rtrim($k, "s") . 's/' . $obj->id);
         } else {
           $this->assertEquals($obj->instanceUrl(), '/push/' . $k . '/' . $obj->id);
         }

--- a/test/Clever/SchoolTest.php
+++ b/test/Clever/SchoolTest.php
@@ -38,10 +38,12 @@ class CleverSchoolTest extends PHPUnit_Framework_TestCase
                               'events'   => 'CleverEvent');
     foreach ($secondLevelTests as $k => $v) {
       $objs = $school->$k();
+      // to ensure every object gets looped over
+      $objs = is_array($objs) ? $objs : array($objs) ;
       foreach ($objs as $obj) {
-        $this->assertEquals(get_class($obj), $v);
+        $this->assertInstanceOf($v, $obj);
         if ($k != "events") {
-          $this->assertEquals($obj->instanceUrl(), '/' . $k . '/' . $obj->id);
+          $this->assertEquals($obj->instanceUrl(), '/' . rtrim($k, "s") . 's/' . $obj->id);
         } else {
           $this->assertEquals($obj->instanceUrl(), '/push/' . $k . '/' . $obj->id);
         }

--- a/test/Clever/SectionTest.php
+++ b/test/Clever/SectionTest.php
@@ -38,10 +38,11 @@ class CleverSectionTest extends PHPUnit_Framework_TestCase
                               'events'   => 'CleverEvent');
     foreach ($secondLevelTests as $k => $v) {
       $objs = $section->$k();
+      $objs = is_array($objs) ? $objs : array($objs) ;
       foreach ($objs as $obj) {
         $this->assertEquals(get_class($obj), $v);
         if ($k != "events") {
-          $this->assertEquals($obj->instanceUrl(), '/' . $k . '/' . $obj->id);
+          $this->assertEquals($obj->instanceUrl(), '/' . rtrim($k, "s") . 's/' . $obj->id);
         } else {
           $this->assertEquals($obj->instanceUrl(), '/push/' . $k . '/' . $obj->id);
         }

--- a/test/Clever/StudentTest.php
+++ b/test/Clever/StudentTest.php
@@ -38,10 +38,11 @@ class CleverStudentTest extends PHPUnit_Framework_TestCase
                               'events'   => 'CleverEvent');
     foreach ($secondLevelTests as $k => $v) {
       $objs = $student->$k();
+      $objs = is_array($objs) ? $objs : array($objs) ;
       foreach ($objs as $obj) {
         $this->assertEquals(get_class($obj), $v);
         if ($k != "events") {
-          $this->assertEquals($obj->instanceUrl(), '/' . $k . '/' . $obj->id);
+          $this->assertEquals($obj->instanceUrl(), '/' . rtrim($k, "s") . 's/' . $obj->id);
         } else {
           $this->assertEquals($obj->instanceUrl(), '/push/' . $k . '/' . $obj->id);
         }

--- a/test/Clever/TeacherTest.php
+++ b/test/Clever/TeacherTest.php
@@ -38,10 +38,11 @@ class CleverTeacherTest extends PHPUnit_Framework_TestCase
                               'events'   => 'CleverEvent');
     foreach ($secondLevelTests as $k => $v) {
       $objs = $teacher->$k();
+      $objs = is_array($objs) ? $objs : array($objs) ;
       foreach ($objs as $obj) {
         $this->assertEquals(get_class($obj), $v);
         if ($k != "events") {
-          $this->assertEquals($obj->instanceUrl(), '/' . $k . '/' . $obj->id);
+          $this->assertEquals($obj->instanceUrl(), '/' . rtrim($k, "s") . 's/' . $obj->id);
         } else {
           $this->assertEquals($obj->instanceUrl(), '/push/' . $k . '/' . $obj->id);
         }

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -13,3 +13,5 @@ function authorizeFromEnv()
 
 require_once(dirname(__FILE__) . '/../lib/Clever.php');
 require_once(dirname(__FILE__) . '/../vendor/autoload.php');
+
+


### PR DESCRIPTION
Second endpoints that didn't end in "s" weren't being caught by the URI matching regex. This PR deals with that issue by untangling the methods that were parsing the URI. 
