### PR TITLE
Use Clever's PHP docker image and repair PHP CI build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,4 +1,4 @@
-image: bradrydzewski/php:5.4
+image: clever/drone-php:5.5-wheezy
 script:
   - curl -sS https://getcomposer.org/installer | php
   - php composer.phar install --prefer-dist --no-interaction --no-progress
@@ -7,12 +7,6 @@ notify:
   email:
     recipients:
       - drone@clever.com
-  hipchat:
-    room: Clever-Dev-CI
-    token: {{hipchatToken}}
-    on_started: true
-    on_success: true
-    on_failure: true
   hipchat:
     room: Clever-Dev-CI
     token: {{hipchatToken}}


### PR DESCRIPTION
Our clever-php build status has been failing for several weeks due to an abandoned docker image dependency. We're now using our own docker image for the PHP environment and the build is fixed, clearing the way for new development.