### PR TITLE
Revise examples and tests to demonstrate usage of cursored pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,21 +70,33 @@ $teacher_students = $teacher->students();
 
 ## Query Parameters
 
-Most API requests allow query parameters for purposes like paging and filtering. The same can be done in the PHP library by passing the `all()` method an associative array of parameters. For example, to see what data has changed since July 23rd, you could run:
+Most API requests allow query parameters for purposes like paging and filtering. The same can be done in the PHP library by passing the `all()` method an associative array of parameters. For example, to retrieve the last Event from the Events API, you could run:
 
 ```php
-$events = CleverEvent::all(array('created_since' => '2012-07-23'));
+$events = CleverEvent::all(array('ending_before' => 'last', 'limit' => 1));
 ```
 
-To page through a lot of data you could do something along the lines of:
+To cursor through larger data sets, capture the last ID of an object in a set, and use it as the `starting_after` value for a subsequent request.
 
 ```php
-for ($page = 1;
-     count($students = CleverStudent::all(array('page' => $page)));
-     $page++) {
-  print_r($students);
-}
+$schools = CleverSchool::all(array('limit' => 1)); # page "one"
+$last_school = $schools[count($schools)-1];
+do {
+  # retrieve page "two" and beyond
+  $more_schools = CleverSchool::all(array('limit' => 1, 'starting_after' => $last_school->id));
+  if(count($more_schools) > 0) {
+    $schools = array_merge($schools, $more_schools);
+    $last_school = $more_schools[count($more_schools)-1];
+  } else {
+    $last_school = NULL;
+  }
+} while($last_school);
+print_r($schools); # Print all the schools retrieved.
 ```
+
+To cursor to a previous page, use the first ID of each set as the `ending_before` value.
+
+Unfortunately, paginating via relative links is not yet supported by clever-php.
 
 ## Composer Support
 

--- a/test/Clever/CursoredPaginationTest.php
+++ b/test/Clever/CursoredPaginationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+class CleverCursoredPaginationTest extends PHPUnit_Framework_TestCase
+{
+  public function testCanRetrieveFirstAndLastIDsOfCollection()
+  {
+    authorizeFromEnv();
+    $students = CleverStudent::all(array("limit" => 2));
+    $oldest = $students[0];
+    $newest = array_pop($students);
+    $oldest_id = $oldest->id;
+    $newest_id = $newest->id;
+    $this->assertInternalType('string', $oldest_id);
+    $this->assertInternalType('string', $newest_id);
+  }
+
+  public function testCanPaginateWithFirstAndLastIDsOfCollection()
+  {
+    authorizeFromEnv();
+    $students = CleverStudent::all(array("limit" => 2));
+    $page_1_handle = array('oldest' => $students[0], 'newest' => end($students));
+    reset($students);
+    # Request two students occuring after our last request
+    $students_page_2 = CleverStudent::all(array("limit" => 2, "starting_after" => $page_1_handle['newest']));
+    $this->assertInternalType('array', $students_page_2);
+    $page_2_handle = array('oldest' => $students_page_2[0], 'newest' => end($students_page_2));
+    reset($students_page_2);
+    # Request the first two students again, or the ones before our last request
+    $students_page_1_again = CleverStudent::all(array("limit" => 2, "ending_before" => $page_2_handle['oldest']));
+    $this->assertInternalType('array', $students_page_1_again);
+    for ($i=0; $i < count($students_page_1_again); $i++) {
+      $this->assertEquals($students_page_1_again[$i], $students[$i]);
+    }
+    $this->assertEquals($students, $students_page_1_again);
+  }
+
+  public function testCanPaginateInALoop() {
+    $schools = CleverSchool::all(array('limit' => 1));
+    $last_school = $schools[count($schools)-1];
+    $incremental_count = count($schools);
+    do {
+      $more_schools = CleverSchool::all(array('limit' => 1, 'starting_after' => $last_school->id));
+      $incremental_count = $incremental_count + count($more_schools);
+      if(count($more_schools) > 0) {
+        $schools = array_merge($schools, $more_schools);
+        $last_school = $more_schools[count($more_schools)-1];
+      } else {
+        $last_school = NULL;
+      }
+    } while($last_school);
+    $this->assertEquals($last_school, NULL);
+    $this->assertEquals(count($schools), $incremental_count);
+  }
+}


### PR DESCRIPTION
It would be better to utilize relative links for collection navigation, but that requires an intensive refactor of clever-php.

However, it is possible to navigate collections with cursors by hand with clever-php.

This PR updates our README.md to use more modern approaches to navigating collections while adding tests demonstrating use.