### PR TITLE
Remove if statement directing events to push/events

### DIFF
--- a/lib/Clever/ApiResource.php
+++ b/lib/Clever/ApiResource.php
@@ -26,8 +26,6 @@ abstract class CleverApiResource extends CleverObject
     $name = urlencode($class);
     $name = strtolower($name);
     $name = "/${name}s";
-    if (strcmp($name, "/events") == 0)
-      $name = '/push/events';
     if (strcmp($name, "/schooladmins") == 0)
       $name = '/school_admins';
     return $name;


### PR DESCRIPTION
It appears the route for events was pointing to push/events, which was working not too long ago. However, it is now throwing a 404 not found error. Changing the route to /events works and pull the event data as expected.