### PR TITLE
Support for `Guardian` relation for `Contact`

### DIFF
--- a/lib/Model/Contact.php
+++ b/lib/Model/Contact.php
@@ -208,6 +208,7 @@ class Contact implements ModelInterface, ArrayAccess
     const PHONE_TYPE_OTHER = 'Other';
     const PHONE_TYPE_EMPTY = '';
     const RELATIONSHIP_PARENT = 'Parent';
+    const RELATIONSHIP_GUARDIAN = 'Guardian';
     const RELATIONSHIP_GRANDPARENT = 'Grandparent';
     const RELATIONSHIP_SELF = 'Self';
     const RELATIONSHIP_AUNTUNCLE = 'Aunt/Uncle';
@@ -249,6 +250,7 @@ class Contact implements ModelInterface, ArrayAccess
     {
         return [
             self::RELATIONSHIP_PARENT,
+            self::RELATIONSHIP_GUARDIAN,
             self::RELATIONSHIP_GRANDPARENT,
             self::RELATIONSHIP_SELF,
             self::RELATIONSHIP_AUNTUNCLE,


### PR DESCRIPTION
Screenshot from Sentry: https://take.ms/bkrnRD

Basically this is straightforward: obviously Contacts now can have relation `Guardian` while it is not part of allowed values declared in Swagger: https://github.com/Clever/swagger-api/blob/master/v2.1-events.yml#L43-L51

Swagger repo fix is very welcome, but this one is of outmost importance, because integration is BROKEN for EVERYONE using this lib